### PR TITLE
 Adding more information to the Request Response, getClient -> Cel

### DIFF
--- a/src/main/java/com/art/experience/dev/model/DTO/DTOClientResponse.java
+++ b/src/main/java/com/art/experience/dev/model/DTO/DTOClientResponse.java
@@ -11,6 +11,7 @@ public class DTOClientResponse {
 	private Long userId;
 	private String name;
 	private String username;
+	private String cel;
 	private boolean status;
 	private String email;
 	private Long socialNumber;
@@ -72,5 +73,17 @@ public class DTOClientResponse {
 
 	public void setSocialNumber(Long socialNumber) {
 		this.socialNumber = socialNumber;
+	}
+
+	public String getCel() {
+		return cel;
+	}
+
+	public void setCel(String cel) {
+		this.cel = cel;
+	}
+
+	public boolean isStatus() {
+		return status;
 	}
 }

--- a/src/main/java/com/art/experience/dev/service/abstractions/UserAbstractFunctions.java
+++ b/src/main/java/com/art/experience/dev/service/abstractions/UserAbstractFunctions.java
@@ -86,7 +86,7 @@ public abstract class UserAbstractFunctions {
 				LOGGER.error("Step to set Client on the result DTO User");
 				DTOClientResponse secureClient = clientService.findByUserId(userResponse.getUserId());
 
-				/** @add: Set Client data for the Response*/
+				/** @add: Set Client data for the Response */
 				if (Objects.nonNull(secureClient)) {
 					user.setClient(secureClient);
 				}
@@ -325,6 +325,7 @@ public abstract class UserAbstractFunctions {
 			clientSecure.setName(clientResult.getName());
 			clientSecure.setStatus(clientResult.getStatus());
 			clientSecure.setSocialNumber(clientResult.getSocialNumber());
+			clientSecure.setCel('0'+String.valueOf(clientResult.getCel()));
 		}
 		return clientSecure;
 	}


### PR DESCRIPTION
Temporally fix:
> We need to include the ´Cel´ attribute to the response of the ´getClient´ **endpoint**

This will resolve an Issue where the frontend is getting whole data from this request and saving on local storage the same.
On the dashboard page, we are getting all information less the cel of the number that backend is not sending..

The reason for this, is that the data sencive is better that dont come from that request, instead from actions reserves request on dashboard page, for that reason they can get all information to resolve the data to show on DialogModal from the Reserves.